### PR TITLE
79 log when program shuts down

### DIFF
--- a/ConsoleApp/Program.cs
+++ b/ConsoleApp/Program.cs
@@ -1,11 +1,13 @@
-﻿using Auxiliary;
+﻿#pragma warning disable IDE0052 // Remove unread private members
+
+using Auxiliary;
 using Core.Main;
 
 namespace ConsoleApp;
 
 internal class Program
 {
-    private static Mutex? _mutex;
+    private static Mutex? _mutex; // Intentionally stored in field to keep it in memory.
     private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
 
     public static void Main(string[] args)

--- a/ConsoleApp/Program.cs
+++ b/ConsoleApp/Program.cs
@@ -1,37 +1,35 @@
 ﻿using Auxiliary;
 using Core.Main;
-using System.Threading;
 
 namespace ConsoleApp;
 
 internal class Program
 {
     private static Mutex? _mutex;
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
 
     public static void Main(string[] args)
     {
         Console.Title = GetTitle();
 
-        var logManager = new LogManager();
+        var logManager = new Auxiliary.LogManager();
         logManager.Initialize();
 
-        var logger = NLog.LogManager.GetCurrentClassLogger();
-        logger.Trace("Initializing application...");
-
+        _logger.Trace("Initializing application...");
         var arguments = Arguments.Parse(args);
         logManager.SetFileLogging(arguments.LogToFile);
         ConsoleManager.SetVisibility(!arguments.HideConsole);
 
         if (IsProgramRunning())
         {
-            logger.Warn("An instance of the program is already running. Quitting application...");
+            _logger.Warn("An instance of the program is already running. Quitting application...");
             Environment.Exit(0);
         }
 
-        logger.Info("Starting application...");
+        _logger.Info("Starting application.");
         new Controller().Run();
 
-        logger.Info("Quitting application...");
+        _logger.Info("Closing application.");
     }
 
     private static string GetTitle()

--- a/ConsoleApp/Program.cs
+++ b/ConsoleApp/Program.cs
@@ -12,6 +12,7 @@ internal class Program
 
     public static void Main(string[] args)
     {
+        RegisterCloseEvents();
         Console.Title = GetTitle();
 
         var logManager = new Auxiliary.LogManager();
@@ -47,5 +48,15 @@ internal class Program
         const string mutexName = "J-Rdp.UniqueInstance";
         _mutex = new Mutex(true, mutexName, out bool isNewInstance);
         return !isNewInstance;
+    }
+
+    private static void RegisterCloseEvents()
+    {
+        AppDomain.CurrentDomain.ProcessExit += OnClose;
+    }
+
+    private static void OnClose(object? sender, EventArgs eventArgs)
+    {
+        _logger.Info("Closing application by request.");
     }
 }


### PR DESCRIPTION
Add logging when the program is gracefully closed, such as by using the bat file or by closing the console window.
Does not work when closed by task manager, since that is forced.