### PR TITLE
82 attached console window

### DIFF
--- a/App/ConsoleManager.cs
+++ b/App/ConsoleManager.cs
@@ -16,6 +16,15 @@ namespace App
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern bool FreeConsole();
 
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr GetConsoleWindow();
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool DeleteMenu(IntPtr hMenu, uint uPosition, uint uFlags);
+
 
 
         public static void SetVisibility(bool show)
@@ -36,6 +45,7 @@ namespace App
             }
 
             SetConsoleTitle("J-Rdp log");
+            DisableConsoleCloseButton();
             RegisterCloseEvents();
 
             // Redirect standard output and error streams to the console
@@ -43,7 +53,22 @@ namespace App
             Console.SetOut(consoleOut);
             Console.SetError(consoleOut);
 
+            Console.WriteLine("""
+                *****************************************************
+                Press ctrl+C to safely close the log console window.
+                Closing it from Windows will also close the main app.
+                *****************************************************
+
+                """);
             _logger.Info("Opened console.");
+        }
+
+        private static void DisableConsoleCloseButton()
+        {
+            IntPtr consoleWindow = GetConsoleWindow();
+            IntPtr systemMenu = GetSystemMenu(consoleWindow, false);
+            if (systemMenu != IntPtr.Zero)
+                DeleteMenu(systemMenu, 0xF060, 0x00000000);
         }
 
         private static void RegisterCloseEvents()

--- a/App/ConsoleManager.cs
+++ b/App/ConsoleManager.cs
@@ -5,6 +5,8 @@ namespace App
 {
     public class ConsoleManager
     {
+        private const string _consoleTitle = "J-Rdp log";
+
         private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
         [DllImport("kernel32.dll", SetLastError = true)]
@@ -12,6 +14,9 @@ namespace App
 
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern bool FreeConsole();
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        private static extern bool SetConsoleTitle(string lpConsoleTitle);
 
 
 
@@ -31,6 +36,8 @@ namespace App
                 _logger.Warn("Failed to open console.");
                 return;
             }
+
+            SetConsoleTitle(_consoleTitle);
 
             // Redirect standard output and error streams to the console
             var consoleOut = new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true };

--- a/App/ConsoleManager.cs
+++ b/App/ConsoleManager.cs
@@ -1,97 +1,96 @@
 ﻿using NLog;
 using System.Runtime.InteropServices;
 
-namespace App
+namespace App;
+
+public class ConsoleManager
 {
-    public class ConsoleManager
+    private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    private static extern bool SetConsoleTitle(string lpConsoleTitle);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool AllocConsole();
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool FreeConsole();
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr GetConsoleWindow();
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool DeleteMenu(IntPtr hMenu, uint uPosition, uint uFlags);
+
+
+
+    public static void SetVisibility(bool show)
     {
-        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
-
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool SetConsoleTitle(string lpConsoleTitle);
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern bool AllocConsole();
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern bool FreeConsole();
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern IntPtr GetConsoleWindow();
-
-        [DllImport("user32.dll", SetLastError = true)]
-        private static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);
-
-        [DllImport("user32.dll", SetLastError = true)]
-        private static extern bool DeleteMenu(IntPtr hMenu, uint uPosition, uint uFlags);
-
-
-
-        public static void SetVisibility(bool show)
-        {
-            if (show)
-                OpenConsole();
-            else
-                CloseConsole();
-        }
-
-        private static void OpenConsole()
-        {
-            bool isSuccess = AllocConsole();
-            if (!isSuccess)
-            {
-                _logger.Warn("Failed to open console.");
-                return;
-            }
-
-            SetConsoleTitle("J-Rdp log");
-            DisableConsoleCloseButton();
-            RegisterCloseEvents();
-            RedirectConsoleOutput();
-
-            Console.WriteLine("""
-                *****************************************************
-                Press ctrl+C to safely close the log console window.
-                Closing it from Windows will also close the main app.
-                *****************************************************
-
-                """);
-            _logger.Info("Opened console.");
-        }
-
-        private static void DisableConsoleCloseButton()
-        {
-            IntPtr consoleWindow = GetConsoleWindow();
-            IntPtr systemMenu = GetSystemMenu(consoleWindow, false);
-            if (systemMenu != IntPtr.Zero)
-                DeleteMenu(systemMenu, 0xF060, 0x00000000);
-        }
-
-        private static void RegisterCloseEvents()
-        {
-            Console.CancelKeyPress += OnCancelKeyPress;
-        }
-
-        private static void OnCancelKeyPress(object? sender, ConsoleCancelEventArgs eventArgs)
-        {
-            eventArgs.Cancel = true; // Prevents the console from closing and taking the main app with it.
+        if (show)
+            OpenConsole();
+        else
             CloseConsole();
+    }
+
+    private static void OpenConsole()
+    {
+        bool isSuccess = AllocConsole();
+        if (!isSuccess)
+        {
+            _logger.Warn("Failed to open console.");
+            return;
         }
 
-        private static void RedirectConsoleOutput()
-        {
-            var consoleOutput = new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true };
-            Console.SetOut(consoleOutput);
-            Console.SetError(consoleOutput);
-        }
+        SetConsoleTitle("J-Rdp log");
+        DisableConsoleCloseButton();
+        RegisterCloseEvents();
+        RedirectConsoleOutput();
 
-        private static void CloseConsole()
-        {
-            bool isSuccess = FreeConsole(); // Close the console without closing the main app.
-            if (isSuccess)
-                _logger.Info("Closed console.");
-            else
-                _logger.Warn("Failed to close console.");
-        }
+        Console.WriteLine("""
+            *****************************************************
+            Press ctrl+C to safely close the log console window.
+            Closing it from Windows will also close the main app.
+            *****************************************************
+
+            """);
+        _logger.Info("Opened console.");
+    }
+
+    private static void DisableConsoleCloseButton()
+    {
+        IntPtr consoleWindow = GetConsoleWindow();
+        IntPtr systemMenu = GetSystemMenu(consoleWindow, false);
+        if (systemMenu != IntPtr.Zero)
+            DeleteMenu(systemMenu, 0xF060, 0x00000000);
+    }
+
+    private static void RegisterCloseEvents()
+    {
+        Console.CancelKeyPress += OnCancelKeyPress;
+    }
+
+    private static void OnCancelKeyPress(object? sender, ConsoleCancelEventArgs eventArgs)
+    {
+        eventArgs.Cancel = true; // Prevents the console from closing and taking the main app with it.
+        CloseConsole();
+    }
+
+    private static void RedirectConsoleOutput()
+    {
+        var consoleOutput = new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true };
+        Console.SetOut(consoleOutput);
+        Console.SetError(consoleOutput);
+    }
+
+    private static void CloseConsole()
+    {
+        bool isSuccess = FreeConsole(); // Close the console without closing the main app.
+        if (isSuccess)
+            _logger.Info("Closed console.");
+        else
+            _logger.Warn("Failed to close console.");
     }
 }

--- a/App/ConsoleManager.cs
+++ b/App/ConsoleManager.cs
@@ -25,14 +25,28 @@ namespace App
 
         private static void OpenConsole()
         {
-            AllocConsole();
+            bool isSuccess = AllocConsole();
+            if (!isSuccess)
+            {
+                _logger.Warn("Failed to open console.");
+                return;
+            }
+
+            // Redirect standard output and error streams to the console
+            var consoleOut = new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true };
+            Console.SetOut(consoleOut);
+            Console.SetError(consoleOut);
+
             _logger.Info("Opened console.");
         }
 
         private static void CloseConsole()
         {
-            FreeConsole();
-            _logger.Info("Closed console.");
+            bool isSuccess = FreeConsole();
+            if (isSuccess)
+                _logger.Info("Closed console.");
+            else
+                _logger.Warn("Failed to close console.");
         }
     }
 }

--- a/App/ConsoleManager.cs
+++ b/App/ConsoleManager.cs
@@ -38,6 +38,7 @@ namespace App
             }
 
             SetConsoleTitle(_consoleTitle);
+            RegisterCloseEvents();
 
             // Redirect standard output and error streams to the console
             var consoleOut = new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true };
@@ -45,11 +46,24 @@ namespace App
             Console.SetError(consoleOut);
 
             _logger.Info("Opened console.");
+
+            
+        }
+
+        private static void RegisterCloseEvents()
+        {
+            Console.CancelKeyPress += OnCancelKeyPress;
+        }
+
+        private static void OnCancelKeyPress(object? sender, ConsoleCancelEventArgs eventArgs)
+        {
+            eventArgs.Cancel = true; // Prevents the console from closing, and taking the main app with it.
+            CloseConsole();
         }
 
         private static void CloseConsole()
         {
-            bool isSuccess = FreeConsole();
+            bool isSuccess = FreeConsole(); // Close the console without closing the main app.
             if (isSuccess)
                 _logger.Info("Closed console.");
             else

--- a/App/ConsoleManager.cs
+++ b/App/ConsoleManager.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace App;
 
+/// <summary> Windows exclusive manager for opening and closing a console log window </summary>
 public class ConsoleManager
 {
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();

--- a/App/ConsoleManager.cs
+++ b/App/ConsoleManager.cs
@@ -1,9 +1,38 @@
-﻿namespace App;
+﻿using NLog;
+using System.Runtime.InteropServices;
 
-public class ConsoleManager // TODO: Implement console manager
+namespace App
 {
-    public static void SetVisibility(bool show)
+    public class ConsoleManager
     {
-        //throw new NotImplementedException();
+        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool AllocConsole();
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool FreeConsole();
+
+
+
+        public static void SetVisibility(bool show)
+        {
+            if (show)
+                OpenConsole();
+            else
+                CloseConsole();
+        }
+
+        private static void OpenConsole()
+        {
+            AllocConsole();
+            _logger.Info("Opened console.");
+        }
+
+        private static void CloseConsole()
+        {
+            FreeConsole();
+            _logger.Info("Closed console.");
+        }
     }
 }

--- a/App/ConsoleManager.cs
+++ b/App/ConsoleManager.cs
@@ -5,18 +5,16 @@ namespace App
 {
     public class ConsoleManager
     {
-        private const string _consoleTitle = "J-Rdp log";
-
         private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        private static extern bool SetConsoleTitle(string lpConsoleTitle);
 
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern bool AllocConsole();
 
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern bool FreeConsole();
-
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool SetConsoleTitle(string lpConsoleTitle);
 
 
 
@@ -37,7 +35,7 @@ namespace App
                 return;
             }
 
-            SetConsoleTitle(_consoleTitle);
+            SetConsoleTitle("J-Rdp log");
             RegisterCloseEvents();
 
             // Redirect standard output and error streams to the console
@@ -46,8 +44,6 @@ namespace App
             Console.SetError(consoleOut);
 
             _logger.Info("Opened console.");
-
-            
         }
 
         private static void RegisterCloseEvents()
@@ -57,7 +53,7 @@ namespace App
 
         private static void OnCancelKeyPress(object? sender, ConsoleCancelEventArgs eventArgs)
         {
-            eventArgs.Cancel = true; // Prevents the console from closing, and taking the main app with it.
+            eventArgs.Cancel = true; // Prevents the console from closing and taking the main app with it.
             CloseConsole();
         }
 

--- a/App/ConsoleManager.cs
+++ b/App/ConsoleManager.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace App;
 
 /// <summary> Windows exclusive manager for opening and closing a console log window </summary>
-public class ConsoleManager
+internal class ConsoleManager
 {
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 

--- a/App/ConsoleManager.cs
+++ b/App/ConsoleManager.cs
@@ -47,11 +47,7 @@ namespace App
             SetConsoleTitle("J-Rdp log");
             DisableConsoleCloseButton();
             RegisterCloseEvents();
-
-            // Redirect standard output and error streams to the console
-            var consoleOut = new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true };
-            Console.SetOut(consoleOut);
-            Console.SetError(consoleOut);
+            RedirectConsoleOutput();
 
             Console.WriteLine("""
                 *****************************************************
@@ -80,6 +76,13 @@ namespace App
         {
             eventArgs.Cancel = true; // Prevents the console from closing and taking the main app with it.
             CloseConsole();
+        }
+
+        private static void RedirectConsoleOutput()
+        {
+            var consoleOutput = new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true };
+            Console.SetOut(consoleOutput);
+            Console.SetError(consoleOutput);
         }
 
         private static void CloseConsole()

--- a/App/Program.cs
+++ b/App/Program.cs
@@ -28,10 +28,10 @@ internal static class Program
             Environment.Exit(0);
         }
 
-        _logger.Info("Starting application.");
+        _logger.Info("***** Starting application. *****");
         Application.Run();
 
-        _logger.Info("Closing application.");
+        _logger.Info("***** Closing application. *****");
     }
 
     private static bool IsProgramRunning()


### PR DESCRIPTION
Closing the console windows closes the main app for now.
Using ctrl+C to close the console works, the main app remains open.
Created a separate issue for a possible fix to this problem, but this will suffice for now.