### PR TITLE
117 toggling profile in menu detects config update twice

### DIFF
--- a/Core/Controller.cs
+++ b/Core/Controller.cs
@@ -39,7 +39,7 @@ public class Controller
 
     public void UpdateProfilesEnabledState(List<ProfileInfo> profileInfos)
     {
-        _configManager.UpdateConfigFileProfiles(profileInfos);
+        _configManager.UpdateProfilesEnabledState(profileInfos);
         _configManager.UpdateConfigFromFile();
         _configManager.InvokeConfigUpdatedCallback();
     }

--- a/Core/Controller.cs
+++ b/Core/Controller.cs
@@ -40,8 +40,6 @@ public class Controller
     public void UpdateProfilesEnabledState(List<ProfileInfo> profileInfos)
     {
         _configManager.UpdateProfilesEnabledState(profileInfos);
-        _configManager.UpdateConfigFromFile();
-        _configManager.InvokeConfigUpdatedCallback();
     }
 
 

--- a/Core/Managers/ConfigManager.cs
+++ b/Core/Managers/ConfigManager.cs
@@ -69,7 +69,7 @@ internal class ConfigManager
             _callback_ConfigUpdated.Invoke(profileInfos); // Invoke on current thread.
     }
 
-    public void UpdateConfigFileProfiles(List<ProfileInfo> profileInfos)
+    public void UpdateProfilesEnabledState(List<ProfileInfo> profileInfos)
     {
         var profiles = ProfileHelper.GetDeepCopies(Config.Profiles);
         ProfileHelper.SetEnabledStatesFromMatchingProfileInfos(profiles, profileInfos);

--- a/WinApp/Managers/CoreManager.cs
+++ b/WinApp/Managers/CoreManager.cs
@@ -17,13 +17,16 @@ internal class CoreManager
         _controller?.Run();
     }
 
+    /// <summary>
+    /// Tell the core controller which method should be called after the config file has been updated.
+    /// </summary>
     public void SetCallback_ConfigUpdated(ProfileHandler callback)
     {
         _controller?.SetCallback_ConfigUpdated(callback);
     }
 
     /// <summary>
-    /// Tell the core controller to update the profiles enabled state, including in the config file.
+    /// Tell the core controller to update the profiles enabled state (in config file and memory).
     /// </summary>
     public void UpdateProfilesEnabledState(List<ProfileInfo> profileInfos)
     {


### PR DESCRIPTION
Behavior is caused by File.WriteAllText(), it is apparently normal. (One change for file truncation and one for entering the new content.)
Will instead debounce the change event, see #119 

As a bonus, did some minor cleanup instead.