### PR TITLE
Use escaped backslash in example profile path

### DIFF
--- a/Core/J-Rdp config.json
+++ b/Core/J-Rdp config.json
@@ -17,7 +17,7 @@
     {
       "enabled": true,
       "name": "Example profile 2",
-      "watchFolder": "C:/Foo/Bar",
+      "watchFolder": "C:\\Foo\\Bar",
       "filter": "abc??.rdp",
       "moveToFolder": "Baz",
       "launch": true,


### PR DESCRIPTION
The readme was already updated with this info, but an example profile now uses the `\\` pathing.